### PR TITLE
Redirect library output to logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ before_install:
   - sudo apt-get install -qq libgmp-dev libgmp10
 
   # Install latest release of qsopt-ex library
-  - wget https://github.com/jonls/qsopt-ex/releases/download/v2.5.10.2/qsopt-ex2_2.5.10.2-0ubuntu1_amd64.deb
-  - sudo dpkg -i qsopt-ex2_2.5.10.2-0ubuntu1_amd64.deb
-  - wget https://github.com/jonls/qsopt-ex/releases/download/v2.5.10.2/qsopt-ex-dev_2.5.10.2-0ubuntu1_amd64.deb
-  - sudo dpkg -i qsopt-ex-dev_2.5.10.2-0ubuntu1_amd64.deb
+  - wget https://github.com/jonls/qsopt-ex/releases/download/v2.5.10.3/qsopt-ex2_2.5.10.3-1_amd64.deb
+  - sudo dpkg -i qsopt-ex2_2.5.10.3-1_amd64.deb
+  - wget https://github.com/jonls/qsopt-ex/releases/download/v2.5.10.3/qsopt-ex-dev_2.5.10.3-1_amd64.deb
+  - sudo dpkg -i qsopt-ex-dev_2.5.10.3-1_amd64.deb
 
   # Install Cython
   - pip install cython

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ Building
 --------
 
 The module requires the QSopt\_ex library to be installed. Currently,
-the modified version at https://github.com/jonls/qsopt-ex is required.
+the modified version at https://github.com/jonls/qsopt-ex is required at
+version 2.5.10.3 or later.
 
 Use ``setup.py`` to build the extension. The setup script is based on
 ``distutils``.

--- a/cqsoptex.pxd
+++ b/cqsoptex.pxd
@@ -92,3 +92,8 @@ cdef extern from 'qsopt_ex/exact.h' nogil:
 
     int QSexact_solver(mpq_QSdata* problem, mpq_t* const x, mpq_t* const y, QSbasis* const basis, int simplexalgo, int* status)
     void QSexact_set_precision(unsigned int precision)
+
+cdef extern from 'qsopt_ex/logging.h' nogil:
+    ctypedef void (*QSlog_func)(const char* message, void* data);
+
+    void QSlog_set_handler(QSlog_func log_func, void* data);

--- a/qsoptex.pyx
+++ b/qsoptex.pyx
@@ -4,6 +4,7 @@ cimport cqsoptex
 cimport cgmp
 
 import numbers, fractions
+import logging
 
 
 # Initialize library
@@ -11,6 +12,15 @@ import numbers, fractions
 # run cqsoptex.QSexactClear()
 cqsoptex.QSexactStart()
 cqsoptex.QSexact_set_precision(128)
+
+# Setup logging for library
+logger = logging.getLogger(__name__)
+
+cdef void _python_log_func(const char* message, void* data):
+    logger.debug(message)
+
+cqsoptex.QSlog_set_handler(
+    <cqsoptex.QSlog_func>_python_log_func, NULL)
 
 
 ### Constants

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     name='python-qsoptex',
     version='0.1',
     license='GPLv3+',
-    url='https://github.com/jonls/qsopt-ex',
+    url='https://github.com/jonls/python-qsoptex',
     author='Jon Lund Steffensen',
     author_email='jonlst@gmail.com',
 


### PR DESCRIPTION
Redirect library output through the Python logging module. This depends on a new interface in QSopt_ex that is not yet released.
