### PR TITLE
Redirect library output to logging

### DIFF
--- a/cqsoptex.pxd
+++ b/cqsoptex.pxd
@@ -92,3 +92,8 @@ cdef extern from 'qsopt_ex/exact.h' nogil:
 
     int QSexact_solver(mpq_QSdata* problem, mpq_t* const x, mpq_t* const y, QSbasis* const basis, int simplexalgo, int* status)
     void QSexact_set_precision(unsigned int precision)
+
+cdef extern from 'qsopt_ex/logging.h' nogil:
+    ctypedef void (*QSlog_func)(const char* message, void* data);
+
+    void QSlog_set_handler(QSlog_func log_func, void* data);

--- a/qsoptex.pyx
+++ b/qsoptex.pyx
@@ -4,6 +4,7 @@ cimport cqsoptex
 cimport cgmp
 
 import numbers, fractions
+import logging
 
 
 # Initialize library
@@ -11,6 +12,15 @@ import numbers, fractions
 # run cqsoptex.QSexactClear()
 cqsoptex.QSexactStart()
 cqsoptex.QSexact_set_precision(128)
+
+# Setup logging for library
+logger = logging.getLogger(__name__)
+
+cdef void _python_log_func(const char* message, void* data):
+    logger.debug(message)
+
+cqsoptex.QSlog_set_handler(
+    <cqsoptex.QSlog_func>_python_log_func, NULL)
 
 
 ### Constants


### PR DESCRIPTION
Redirect library output through the Python logging module.
